### PR TITLE
fix: avoid temporary file for key meterial

### DIFF
--- a/bw_ssh_agent.py
+++ b/bw_ssh_agent.py
@@ -196,21 +196,14 @@ class BitwardenSSHAgent:
         """Add an SSH key to the SSH agent."""
         temp_key_file = None
         try:
-            # Create a temporary file to store the key
-            temp_key_file = tempfile.NamedTemporaryFile(mode='wt', delete=False)
-            temp_key_file.write(key_data["sshKey"]["privateKey"])
-            temp_key_file.flush()
-            os.fsync(temp_key_file.fileno())  # Ensure the content is written to disk
-            # Set correct permissions
-            os.chmod(temp_key_file.name, 0o600)
-            
             # Add key to agent with environment variables
             env = os.environ.copy()
             result = subprocess.run(
-                ["ssh-add", temp_key_file.name],
+                ["ssh-add", "-"],
                 capture_output=True,
                 text=True,
-                env=env
+                env=env,
+                input=key_data["sshKey"]["privateKey"]
             )
             
             if result.returncode != 0:


### PR DESCRIPTION
The README.md states: *Never stores SSH keys on disk*

However [NamedTemporaryFile](https://github.com/playX18/bw_ssh_agent/blob/a75138f72dbb18305fe5ae7b3ddb1e5f305376a0/bw_ssh_agent.py#L200) is used.

```
This function operates exactly as TemporaryFile() does, except the following differences:

   *  This function returns a file that is guaranteed to have a visible name in the file system.
   * To manage the named file, it extends the parameters of TemporaryFile() with delete and delete_on_close parameters that determine whether and how the named file should be automatically deleted.
```
-- https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile

We can avoid dealing with temp files all together, we can't trust these to be in memory. 